### PR TITLE
Add a new "parts" argument

### DIFF
--- a/lib/DateTime/Format/Human/Duration.pm
+++ b/lib/DateTime/Format/Human/Duration.pm
@@ -115,6 +115,9 @@ sub format_duration {
         }
 
         push(@parts, $val . ' ' . $setup->{$setup_key});
+        if (exists $args{'parts'}) {
+            last if scalar(@parts) == $args{'parts'};
+        }
     }
     
     my $no_time = exists $args{'no_time'} ? $args{'no_time'} : $setup->{'no_time'};
@@ -271,6 +274,22 @@ Example:
   
     print $fmt->format_duration($d, 'precision' => 'days');
     # '1 year, 7 months, 2 weeks, and 2 days'
+
+=item * parts
+
+By default, the duration will be formatted using all specified units.  To restrict the number of units output, set this to a value of one or more.
+
+Example:
+
+    my $fmt = DateTime::Format::Human::Duration->new();
+    my $d = DateTime::Duration->new(...);
+  
+    print $fmt->format_duration($d, 'parts' => 1);
+    # '3 days'
+    print $fmt->format_duration($d, 'parts' => 2);
+    # '3 days and 10 hours'
+    print $fmt->format_duration($d, 'parts' => 3);
+    # '3 days, 10 hours, and 27 minutes'
 
 =back
 

--- a/t/01.methods.t
+++ b/t/01.methods.t
@@ -64,6 +64,12 @@ SKIP: {
     is( $span->format_duration($dure, 'locale' => $dub->{'locale'}), '1 minute et 3 seconds', 'locale key as $DateTime->{\'locale\'} format_duration()');
     is( $span->format_duration_between($dub, $duc), '1 minute et 1 seconde', 'Object\'s locale used in format_duration_between()');
 
+    # test 'parts'
+    is( $span->format_duration($dure, parts => 1), '1 minute', 'only show one part' );
+    is( $span->format_duration($dure, parts => 99), '1 minute and 3 seconds', 'show up to 99 part' );
+    is( $span->format_duration($durf, parts => 1), '1 hour', 'show 1 unit of 3' );
+    is( $span->format_duration($durf, parts => 2), '1 hour and 25 seconds', 'show 2 units of 3' );
+    is( $span->format_duration($durf, parts => 3), '1 hour, 25 seconds, and 445499897 nanoseconds', 'show 3 units of 3' );
 };
 
 done_testing();


### PR DESCRIPTION
Hi,

I found myself wanting to output durations in the style of "15 minutes ago" or "3 weeks ago" and DateTime::Format::Human::Duration almost did the job.  I've added a new argument to let me do this.  I'm unsure whether I've named or documented this quite right, so you might want to change those, but I think adding a feature to let users show only the "n" most significant units (where "n=1" in my case) would be a good idea.

Thanks for your work on this useful CPAN module,
Tom
