### PR TITLE
Correct typos detected by Lintian

### DIFF
--- a/README
+++ b/README
@@ -213,7 +213,7 @@ LOCALIZATION of DateTime::Format modules
     XYZ::Locale should handle looking up (and caching if appropriate) the
     locale and loading the necessary locale module XYZ::Locale::fr
 
-    The specific locale module holds the data and possibly logic neccesary
+    The specific locale module holds the data and possibly logic necessary
     to do what XYZ does in the vernacular of the given locale.
 
   TODO

--- a/lib/DateTime/Format/Human/Duration.pm
+++ b/lib/DateTime/Format/Human/Duration.pm
@@ -366,7 +366,7 @@ The idea is to determine the locale to use based on a DateTime object.
 
 XYZ::Locale should handle looking up (and caching if appropriate) the locale and loading the necessary locale module XYZ::Locale::fr
 
-The specific locale module holds the data and possibly logic neccesary to do what XYZ does in the vernacular of the given locale.
+The specific locale module holds the data and possibly logic necessary to do what XYZ does in the vernacular of the given locale.
 
 =head2 TODO 
 


### PR DESCRIPTION
Correct a couple of typos detected by the lintian tool when packaging this distribution for Debian